### PR TITLE
cmd/pippi: validate binId input prior to use

### DIFF
--- a/cmd/pi-disasm/client.go
+++ b/cmd/pi-disasm/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/subcommands"
 	"github.com/kr/pretty"
 	"github.com/lapsang-boys/pippi/cmd/pi-bin/binpbx"
+	"github.com/lapsang-boys/pippi/pkg/pi"
 	binpb "github.com/lapsang-boys/pippi/proto/bin"
 	disasmpb "github.com/lapsang-boys/pippi/proto/disasm"
 	"github.com/pkg/errors"
@@ -71,7 +72,7 @@ func (cmd *clientCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 // connect connects to the given gRPC address to send a disassemble binary file
 // reuquest.
 func connect(binAddr, disasmAddr, binID string) error {
-	if err := validateID(binID); err != nil {
+	if err := pi.CheckBinID(binID); err != nil {
 		return errors.WithStack(err)
 	}
 	dbg.Printf("connecting to %q", disasmAddr)

--- a/cmd/pi-disasm/server.go
+++ b/cmd/pi-disasm/server.go
@@ -2,16 +2,15 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"flag"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/subcommands"
 	"github.com/lapsang-boys/pippi/cmd/pi-bin/binpbx"
+	"github.com/lapsang-boys/pippi/pkg/pi"
 	binpb "github.com/lapsang-boys/pippi/proto/bin"
 	disasmpb "github.com/lapsang-boys/pippi/proto/disasm"
 	"github.com/pkg/errors"
@@ -102,7 +101,7 @@ type disasmServer struct {
 
 // Disassemble disassembles the given binary file.
 func (s *disasmServer) Disassemble(ctx context.Context, req *disasmpb.DisassembleRequest) (*disasmpb.DisassembleReply, error) {
-	if err := validateID(req.BinId); err != nil {
+	if err := pi.CheckBinID(req.BinId); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	dbg.Printf("disassembling ID %q", req.BinId)
@@ -162,22 +161,4 @@ func permContains(perms []binpb.Perm, perm binpb.Perm) bool {
 		}
 	}
 	return false
-}
-
-// validateID validates the given binary ID.
-func validateID(id string) error {
-	if sha256.Size*2 != len(id) {
-		return errors.Errorf("invalid length of binary ID; expected %d, got %d", sha256.Size*2, len(id))
-	}
-	s := strings.ToLower(id)
-	if s != id {
-		return errors.Errorf("invalid binary ID; expected lowercase, got %q", id)
-	}
-	const hex = "0123456789abcdef"
-	for _, r := range id {
-		if !strings.ContainsRune(hex, r) {
-			return errors.Errorf("invalid rune in binary ID; expected hexadecimal digit, got %q", r)
-		}
-	}
-	return nil
 }

--- a/cmd/pippi/main.go
+++ b/cmd/pippi/main.go
@@ -9,12 +9,17 @@ import (
 	"github.com/leaanthony/mewn"
 	"github.com/wailsapp/wails"
 
+	"github.com/lapsang-boys/pippi/pkg/pi"
 	binpb "github.com/lapsang-boys/pippi/proto/bin"
 	disasmpb "github.com/lapsang-boys/pippi/proto/disasm"
 	stringspb "github.com/lapsang-boys/pippi/proto/strings"
 )
 
 func binary(binId string) []byte {
+	if err := pi.CheckBinID(binId); err != nil {
+		log.Printf("invalid binary ID %q: %v", binId, err)
+		return nil
+	}
 	const (
 		ext = ".bin"
 	)
@@ -37,6 +42,10 @@ func binary(binId string) []byte {
 }
 
 func sections(binId string) *binpb.File {
+	if err := pi.CheckBinID(binId); err != nil {
+		log.Printf("invalid binary ID %q: %v", binId, err)
+		return nil
+	}
 	file, err := Sections("localhost:1200", binId)
 	if err != nil {
 		log.Println(err)
@@ -46,6 +55,10 @@ func sections(binId string) *binpb.File {
 }
 
 func disassembly(binId string) *disasmpb.DisassembleReply {
+	if err := pi.CheckBinID(binId); err != nil {
+		log.Printf("invalid binary ID %q: %v", binId, err)
+		return nil
+	}
 	reply, err := Disassembly("localhost:1300", binId)
 	if err != nil {
 		log.Println(err)
@@ -55,6 +68,10 @@ func disassembly(binId string) *disasmpb.DisassembleReply {
 }
 
 func strings(binId string) []*stringspb.StringInfo {
+	if err := pi.CheckBinID(binId); err != nil {
+		log.Printf("invalid binary ID %q: %v", binId, err)
+		return nil
+	}
 	extractedStrings, err := Strings("localhost:1400", binId)
 	if err != nil {
 		log.Println(err)

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -1,0 +1,26 @@
+// Package pi implements utility functions shared across Pippi.
+package pi
+
+import (
+	"crypto/sha256"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// CheckBinID validates the given binary ID.
+func CheckBinID(id string) error {
+	if len(id) != sha256.Size*2 {
+		return errors.Errorf("invalid length of binary ID; expected %d, got %d", sha256.Size*2, len(id))
+	}
+	if id != strings.ToLower(id) {
+		return errors.Errorf("invalid binary ID; expected lowercase, got %q", id)
+	}
+	const hex = "0123456789abcdef"
+	for _, r := range id {
+		if !strings.ContainsRune(hex, r) {
+			return errors.Errorf("invalid rune in binary ID; expected hexadecimal digit, got %q", r)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #13.