### PR TITLE
pi: add BinID, CacheDir, BinDir and BinPath

### DIFF
--- a/cmd/pi-disasm/client.go
+++ b/cmd/pi-disasm/client.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	"github.com/google/subcommands"
 	"github.com/kr/pretty"
@@ -106,18 +104,13 @@ func connect(binAddr, disasmAddr, binID string) error {
 	case binpb.Arch_X86_64:
 		mode = 64
 	}
-	// Get cache directory.
-
 	// TODO: use receive.proto to get file from server. Right now, we assume that
 	// we are running on localhost to read the file contents of binID.
-	cacheDir, err := os.UserCacheDir()
+	// Read file contents.
+	binPath, err := pi.BinPath(binID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	cacheDir = filepath.Join(cacheDir, "pippi")
-	// Read file contents.
-	binName := binID + ext
-	binPath := filepath.Join(cacheDir, binID, binName)
 	binData, err := ioutil.ReadFile(binPath)
 	if err != nil {
 		return errors.WithStack(err)

--- a/cmd/pi-upload/client.go
+++ b/cmd/pi-upload/client.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"flag"
 	"fmt"
 	"io/ioutil"
 
 	"github.com/google/subcommands"
+	"github.com/lapsang-boys/pippi/pkg/pi"
 	uploadpb "github.com/lapsang-boys/pippi/proto/upload"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -65,15 +64,11 @@ func newRequest(binPath string) (*uploadpb.UploadRequest, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	rawHash := sha256.Sum256(buf)
-	hash := hex.EncodeToString(rawHash[:])
-
 	req := &uploadpb.UploadRequest{
 		Filename: binPath,
-		Hash:     hash,
+		Hash:     pi.BinID(buf),
 		Content:  buf,
 	}
-
 	return req, nil
 }
 

--- a/cmd/pi-upload/server.go
+++ b/cmd/pi-upload/server.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"flag"
 	"io/ioutil"
 	"net"
 	"os"
-	"path/filepath"
 
 	"github.com/google/subcommands"
+	"github.com/lapsang-boys/pippi/pkg/pi"
 	uploadpb "github.com/lapsang-boys/pippi/proto/upload"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -18,8 +16,7 @@ import (
 
 const (
 	// Default gRPC address to listen on.
-	grpcAddr  = ":1100"
-	extension = ".bin"
+	grpcAddr = ":1100"
 )
 
 // serverCmd is the command to launch a gRPC server processing parse binary
@@ -61,6 +58,9 @@ func (cmd *serverCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	return subcommands.ExitSuccess
 }
 
+// Maximum file size in bytes.
+const maxFileSize = 1 * 1024 * 1024 * 1024 // 1 GB
+
 // listen listens on the given gRPC address for incoming requests to parse binary
 // files.
 func listen(addr string) error {
@@ -70,54 +70,45 @@ func listen(addr string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	cacheDir = filepath.Join(cacheDir, "pippi")
-
-	err = os.MkdirAll(cacheDir, 0755)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	server := grpc.NewServer(grpc.MaxRecvMsgSize(1 * 1024 * 1024 * 1024))
+	server := grpc.NewServer(grpc.MaxRecvMsgSize(maxFileSize))
 	// Register binary parser service.
-	uploadpb.RegisterUploadServer(server, &uploadServer{cacheDir: cacheDir})
+	uploadpb.RegisterUploadServer(server, &uploadServer{})
 	if err := server.Serve(l); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil
 }
 
-type uploadServer struct {
-	cacheDir string
-}
+// uploadServer handles binary file upload requests.
+type uploadServer struct{}
 
+// Upload handles binary file upload requests.
 func (us uploadServer) Upload(ctx context.Context, req *uploadpb.UploadRequest) (*uploadpb.UploadReply, error) {
 	dbg.Printf("receiving %q", req.Filename)
-
-	rawHash := sha256.Sum256(req.Content)
-	hash := hex.EncodeToString(rawHash[:])
-	if hash != req.Hash {
-		return nil, errors.Errorf("Hash mismatch. Expected %s, got %s", req.Hash, hash)
+	// Compute binary ID based on binary file contents.
+	binID := pi.BinID(req.Content)
+	if binID != req.Hash {
+		return nil, errors.Errorf("hash mismatch; expected %q, got %q", req.Hash, binID)
 	}
-	dirName := filepath.Join(us.cacheDir, req.Hash)
-	err := os.Mkdir(dirName, 0755)
+	// Create project directory for the binary ID.
+	binDir, err := pi.BinDir(binID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	destPath := filepath.Join(dirName, hash+extension)
-
-	err = ioutil.WriteFile(destPath, req.Content, 0644)
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	// Store binary file to disk.
+	binPath, err := pi.BinPath(binID)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
+	if err := ioutil.WriteFile(binPath, req.Content, 0644); err != nil {
+		return nil, errors.WithStack(err)
+	}
 	// Send reply.
 	reply := &uploadpb.UploadReply{
-		Id: hash,
+		Id: binID,
 	}
 	return reply, nil
 }

--- a/cmd/pippi/ladda.go
+++ b/cmd/pippi/ladda.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/lapsang-boys/pippi/pkg/pi"
 	"github.com/pkg/errors"
@@ -71,6 +72,15 @@ func upload(w http.ResponseWriter, r *http.Request) {
 		}
 		rawHash := sha256.Sum256(buf.Bytes())
 		binID := hex.EncodeToString(rawHash[:])
+		binDir, err := pi.BinDir(binID)
+		if err != nil {
+			log.Printf("%+v", errors.WithStack(err))
+			return
+		}
+		if err := os.MkdirAll(binDir, 0755); err != nil {
+			log.Printf("%+v", errors.WithStack(err))
+			return
+		}
 		binPath, err := pi.BinPath(binID)
 		if err != nil {
 			log.Printf("%+v", errors.WithStack(err))

--- a/cmd/pippi/ladda.go
+++ b/cmd/pippi/ladda.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -70,8 +68,7 @@ func upload(w http.ResponseWriter, r *http.Request) {
 			log.Printf("%+v", errors.WithStack(err))
 			return
 		}
-		rawHash := sha256.Sum256(buf.Bytes())
-		binID := hex.EncodeToString(rawHash[:])
+		binID := pi.BinID(buf.Bytes())
 		binDir, err := pi.BinDir(binID)
 		if err != nil {
 			log.Printf("%+v", errors.WithStack(err))

--- a/cmd/pippi/main.go
+++ b/cmd/pippi/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"io/ioutil"
 	"log"
-	"os"
-	"path/filepath"
 
 	"github.com/leaanthony/mewn"
 	"github.com/wailsapp/wails"
@@ -20,19 +18,12 @@ func binary(binId string) []byte {
 		log.Printf("invalid binary ID %q: %v", binId, err)
 		return nil
 	}
-	const (
-		ext = ".bin"
-	)
-
-	cacheDir, err := os.UserCacheDir()
+	binPath, err := pi.BinPath(binId)
 	if err != nil {
-		log.Println(err)
+		log.Println()
 		return []byte{}
 	}
-	cacheDir = filepath.Join(cacheDir, "pippi")
 	// Read file contents.
-	binName := binId + ext
-	binPath := filepath.Join(cacheDir, binId, binName)
 	binData, err := ioutil.ReadFile(binPath)
 	if err != nil {
 		log.Println(err)
@@ -81,13 +72,11 @@ func strings(binId string) []*stringspb.StringInfo {
 }
 
 func listIds() []string {
-	cacheDir, err := os.UserCacheDir()
+	pippiCacheDir, err := pi.CacheDir()
 	if err != nil {
-		log.Println(err)
-		return []string{}
+		log.Fatal(err)
 	}
-	cacheDir = filepath.Join(cacheDir, "pippi")
-	files, err := ioutil.ReadDir(cacheDir)
+	files, err := ioutil.ReadDir(pippiCacheDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/pippi/main.go
+++ b/cmd/pippi/main.go
@@ -20,7 +20,7 @@ func binary(binId string) []byte {
 	}
 	binPath, err := pi.BinPath(binId)
 	if err != nil {
-		log.Println()
+		log.Println(err)
 		return []byte{}
 	}
 	// Read file contents.

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -27,16 +27,25 @@ func CheckBinID(binID string) error {
 	return nil
 }
 
-// BinDir returns the project directory of the given binary ID.
-func BinDir(binID string) (string, error) {
-	if err := CheckBinID(binID); err != nil {
-		return "", errors.WithStack(err)
-	}
+// CacheDir returns the pippi cache directory.
+func CacheDir() (string, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
 	pippiCacheDir := filepath.Join(cacheDir, "pippi")
+	return pippiCacheDir, nil
+}
+
+// BinDir returns the project directory of the given binary ID.
+func BinDir(binID string) (string, error) {
+	if err := CheckBinID(binID); err != nil {
+		return "", errors.WithStack(err)
+	}
+	pippiCacheDir, err := CacheDir()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
 	binDir := filepath.Join(pippiCacheDir, binID)
 	return binDir, nil
 }

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -31,8 +31,8 @@ func CheckBinID(binID string) error {
 
 // BinID returns the binary ID corresponding to the given binary contents. The
 // binary ID is the computed SHA256 hashsum of the binary contents in lowercase.
-func BinID(data []byte) string {
-	rawHash := sha256.Sum256(data)
+func BinID(content []byte) string {
+	rawHash := sha256.Sum256(content)
 	binID := hex.EncodeToString(rawHash[:])
 	// Sanity check.
 	if err := CheckBinID(binID); err != nil {

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -64,7 +64,7 @@ func BinDir(binID string) (string, error) {
 	return binDir, nil
 }
 
-// Binary executable extension.
+// Binary extension.
 const binExt = ".bin"
 
 // BinPath returns the file path to the binary of the given binary ID.

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -3,24 +3,54 @@ package pi
 
 import (
 	"crypto/sha256"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 )
 
 // CheckBinID validates the given binary ID.
-func CheckBinID(id string) error {
-	if len(id) != sha256.Size*2 {
-		return errors.Errorf("invalid length of binary ID; expected %d, got %d", sha256.Size*2, len(id))
+func CheckBinID(binID string) error {
+	if len(binID) != sha256.Size*2 {
+		return errors.Errorf("invalid length of binary ID; expected %d, got %d", sha256.Size*2, len(binID))
 	}
-	if id != strings.ToLower(id) {
-		return errors.Errorf("invalid binary ID; expected lowercase, got %q", id)
+	if binID != strings.ToLower(binID) {
+		return errors.Errorf("invalid binary ID; expected lowercase, got %q", binID)
 	}
 	const hex = "0123456789abcdef"
-	for _, r := range id {
+	for _, r := range binID {
 		if !strings.ContainsRune(hex, r) {
-			return errors.Errorf("invalid rune in binary ID; expected hexadecimal digit, got %q", r)
+			return errors.Errorf("invalid character in binary ID; expected hexadecimal digit, got %q", r)
 		}
 	}
 	return nil
+}
+
+// BinDir returns the project directory of the given binary ID.
+func BinDir(binID string) (string, error) {
+	if err := CheckBinID(binID); err != nil {
+		return "", errors.WithStack(err)
+	}
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	pippiCacheDir := filepath.Join(cacheDir, "pippi")
+	binDir := filepath.Join(pippiCacheDir, binID)
+	return binDir, nil
+}
+
+// Binary executable extension.
+const binExt = ".bin"
+
+// BinPath returns the file path to the binary of the given binary ID.
+func BinPath(binID string) (string, error) {
+	binDir, err := BinDir(binID)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	binName := binID + binExt
+	binPath := filepath.Join(binDir, binName)
+	return binPath, nil
 }

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -3,6 +3,8 @@ package pi
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +27,18 @@ func CheckBinID(binID string) error {
 		}
 	}
 	return nil
+}
+
+// BinID returns the binary ID corresponding to the given binary contents. The
+// binary ID is the computed SHA256 hashsum of the binary contents in lowercase.
+func BinID(data []byte) string {
+	rawHash := sha256.Sum256(data)
+	binID := hex.EncodeToString(rawHash[:])
+	// Sanity check.
+	if err := CheckBinID(binID); err != nil {
+		panic(fmt.Errorf("discripancy between computed binary ID %q and validity check; %+v", binID, err))
+	}
+	return binID
 }
 
 // CacheDir returns the pippi cache directory.


### PR DESCRIPTION
These functions unify handling of binary ID computation, Pippi cache directory, binary directory and binary path resolution across all Go services of Pippi.