### PR TITLE
 proto: add encoding and size fields to strings.proto

### DIFF
--- a/cmd/pi-strings/src/main.rs
+++ b/cmd/pi-strings/src/main.rs
@@ -28,12 +28,12 @@ use regex::Regex;
 #[derive(Clone)]
 struct StringsService;
 
-fn is_valid(id: &str) -> bool {
+fn is_valid(bin_id: &str) -> bool {
     lazy_static! {
         static ref RE: Regex = Regex::new("^[0-9a-f]{64}$").unwrap();
     }
 
-    RE.is_match(id) && id.len() == 64
+    RE.is_match(bin_id) && bin_id.len() == 64
 }
 
 impl strings_grpc::StringsExtractor for StringsService {
@@ -43,10 +43,10 @@ impl strings_grpc::StringsExtractor for StringsService {
         req: strings::StringsRequest,
         sink: UnarySink<strings::StringsReply>,
     ) {
-        let id = req.get_id();
-        println!("{}", id);
-        println!("{}", is_valid(id));
-        if !is_valid(id) {
+        let bin_id = req.get_bin_id();
+        println!("{}", bin_id);
+        println!("{}", is_valid(bin_id));
+        if !is_valid(bin_id) {
             let status = RpcStatus::new(
                 RpcStatusCode::InvalidArgument,
                 Some("Invalid argument".to_string()),
@@ -61,8 +61,8 @@ impl strings_grpc::StringsExtractor for StringsService {
         let filename = base_dirs
             .cache_dir()
             .join("pippi")
-            .join(id)
-            .join(id.to_owned() + ".bin")
+            .join(bin_id)
+            .join(bin_id.to_owned() + ".bin")
             .to_str()
             .unwrap()
             .to_string();
@@ -132,6 +132,8 @@ fn extract_strings_from_path(filename: String) -> Result<Vec<strings::StringInfo
                 let mut sinfo = strings::StringInfo::default();
                 sinfo.set_location((index - s.len()) as u64);
                 sinfo.set_raw_string(s.to_string());
+                sinfo.set_size(s.len() as u64);
+                sinfo.set_encoding(strings::Encoding::UTF8);
                 sinfos.push(sinfo);
                 debug!("{} {}", index - s.len(), s);
             }

--- a/cmd/pippi/client.go
+++ b/cmd/pippi/client.go
@@ -25,7 +25,7 @@ func Strings(addr, binId string) ([]*stringspb.StringInfo, error) {
 	ctx := context.Background()
 
 	req := &stringspb.StringsRequest{
-		Id: binId,
+		BinId: binId,
 	}
 	now := time.Now()
 	reply, err := client.ExtractStrings(ctx, req)

--- a/proto/strings.proto
+++ b/proto/strings.proto
@@ -3,19 +3,39 @@ syntax = "proto3";
 package strings;
 
 service StringsExtractor {
-   rpc ExtractStrings (StringsRequest) returns (StringsReply) {}
+	rpc ExtractStrings (StringsRequest) returns (StringsReply) {}
 }
 
 message StringsRequest {
-   // ID of file.
-   string id = 1;
+	// Binary ID.
+	string bin_id = 1;
 }
 
 message StringInfo {
+	// File offset to start of string.
 	uint64 location = 1;
+	// String in UTF-8 encoding.
 	string raw_string = 2;
+	// Size of string in bytes.
+	uint64 size = 3;
+	// Encoding of string.
+	Encoding encoding = 4;
 }
 
 message StringsReply {
-   repeated StringInfo strings = 1;
+	repeated StringInfo strings = 1;
+}
+
+// String encodings.
+enum Encoding {
+	// ASCII encoding.
+	ASCII = 0;
+	// UTF-8 encoding.
+	UTF8 = 1;
+	// UTF-16 encoding.
+	UTF16 = 2;
+	// UTF-32 encoding
+	UTF32 = 3;
+	// Big-5 encoding.
+	Big5 = 4;
 }

--- a/proto/strings.proto
+++ b/proto/strings.proto
@@ -32,10 +32,12 @@ enum Encoding {
 	ASCII = 0;
 	// UTF-8 encoding.
 	UTF8 = 1;
-	// UTF-16 encoding.
-	UTF16 = 2;
+	// UTF-16 encoding (little endian).
+	UTF16LittleEndian = 2;
+	// UTF-16 encoding (big endian).
+	UTF16BigEndian = 3;
 	// UTF-32 encoding
-	UTF32 = 3;
+	UTF32 = 4;
 	// Big-5 encoding.
-	Big5 = 4;
+	Big5 = 5;
 }


### PR DESCRIPTION
To be able to add support for extracting strings of
other encodings than ASCII and UTF-8, we should store
the original encoding of the strings extracted by
pi-strings.

Also, since the length in characters of an extracted
string may differ from the size in number of bytes
that the string contents took in the binary executable,
a size field is added.

~**Note**: this PR depends on #16.~