### PR TITLE
cmd/pi-disasm-new: preliminary implementation of simple disassembler

### DIFF
--- a/cmd/pi-disasm-new/.gitignore
+++ b/cmd/pi-disasm-new/.gitignore
@@ -1,0 +1,4 @@
+*.json
+ls
+*.exe
+*.bin

--- a/cmd/pi-disasm-new/disasm/disasm.go
+++ b/cmd/pi-disasm-new/disasm/disasm.go
@@ -1,0 +1,16 @@
+package disasm
+
+import (
+	"fmt"
+)
+
+// Disassembler is a disassembler for a given machine architecture.
+type Disassembler interface {
+	// DecodeInst decodes the first instruction in buf.
+	DecodeInst(buf []byte) (Instruction, error)
+}
+
+// Instruction is an assembly instruction of a given machine architecture.
+type Instruction interface {
+	fmt.Stringer
+}

--- a/cmd/pi-disasm-new/disasm/disasm.go
+++ b/cmd/pi-disasm-new/disasm/disasm.go
@@ -2,15 +2,19 @@ package disasm
 
 import (
 	"fmt"
+
+	"github.com/decomp/exp/bin"
 )
 
 // Disassembler is a disassembler for a given machine architecture.
 type Disassembler interface {
 	// DecodeInst decodes the first instruction in buf.
-	DecodeInst(buf []byte) (Instruction, error)
+	DecodeInst(addr bin.Address, buf []byte) (Instruction, error)
 }
 
 // Instruction is an assembly instruction of a given machine architecture.
 type Instruction interface {
 	fmt.Stringer
+	// Addr returns the address of the instruction.
+	Addr() bin.Address
 }

--- a/cmd/pi-disasm-new/disasm/format.go
+++ b/cmd/pi-disasm-new/disasm/format.go
@@ -1,0 +1,48 @@
+// Note, the machine architecture format registration implementation of this
+// package is heavily inspired by the image package of the Go standard library,
+// which is governed by a BSD license.
+
+package disasm
+
+import (
+	"github.com/decomp/exp/bin"
+	"github.com/pkg/errors"
+)
+
+// RegisterFormat registers a machine architecture format for use by DecodeInst
+// of a Disassembler. Name is the name of the format, like "x86_32" or
+// "MIPS_32". Arch is is the machine architecture that identifies the format's
+// Instruction Set Architecture (ISA).
+func RegisterFormat(name string, arch bin.Arch, decodeInst func(buf []byte) (Instruction, error)) {
+	formats = append(formats, format{name: name, arch: arch, decodeInst: decodeInst})
+}
+
+// formats is the list of registered formats.
+var formats []format
+
+// A format holds a machine architecture format's name, and details how to
+// decode the instructions of its Instruction Set Architecture (ISA).
+type format struct {
+	// Name of the binary executable format.
+	name string
+	// Machine architecture that identifies the format's encoding.
+	arch bin.Arch
+	// decodeInst decodes the first instruction in buf.
+	decodeInst func(buf []byte) (Instruction, error)
+}
+
+// DecodeInst decodes the first instruction in buf.
+func (format *format) DecodeInst(buf []byte) (Instruction, error) {
+	return format.decodeInst(buf)
+}
+
+// NewDisassembler returns a new disassembler for the given machine
+// architecture.
+func NewDisassembler(arch bin.Arch) (Disassembler, error) {
+	for _, format := range formats {
+		if format.arch == arch {
+			return &format, nil
+		}
+	}
+	return nil, errors.Errorf("unknown machine architecture format %v;\n\ttip: remember to register a disassembler (e.g. import _ \".../disasm/x86\")", arch)
+}

--- a/cmd/pi-disasm-new/disasm/format.go
+++ b/cmd/pi-disasm-new/disasm/format.go
@@ -13,7 +13,7 @@ import (
 // of a Disassembler. Name is the name of the format, like "x86_32" or
 // "MIPS_32". Arch is is the machine architecture that identifies the format's
 // Instruction Set Architecture (ISA).
-func RegisterFormat(name string, arch bin.Arch, decodeInst func(buf []byte) (Instruction, error)) {
+func RegisterFormat(name string, arch bin.Arch, decodeInst func(addr bin.Address, buf []byte) (Instruction, error)) {
 	formats = append(formats, format{name: name, arch: arch, decodeInst: decodeInst})
 }
 
@@ -28,12 +28,12 @@ type format struct {
 	// Machine architecture that identifies the format's encoding.
 	arch bin.Arch
 	// decodeInst decodes the first instruction in buf.
-	decodeInst func(buf []byte) (Instruction, error)
+	decodeInst func(addr bin.Address, buf []byte) (Instruction, error)
 }
 
 // DecodeInst decodes the first instruction in buf.
-func (format *format) DecodeInst(buf []byte) (Instruction, error) {
-	return format.decodeInst(buf)
+func (format *format) DecodeInst(addr bin.Address, buf []byte) (Instruction, error) {
+	return format.decodeInst(addr, buf)
 }
 
 // NewDisassembler returns a new disassembler for the given machine

--- a/cmd/pi-disasm-new/disasm/x86/x86.go
+++ b/cmd/pi-disasm-new/disasm/x86/x86.go
@@ -16,21 +16,33 @@ func init() {
 }
 
 // decodeInst32 decodes the first instruction in buf.
-func decodeInst32(buf []byte) (disasm.Instruction, error) {
+func decodeInst32(addr bin.Address, buf []byte) (disasm.Instruction, error) {
 	const mode = 32 // x86 (32-bit)
 	inst, err := x86asm.Decode(buf, mode)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return inst, nil
+	return &Instruction{Inst: inst, addr: addr}, nil
 }
 
 // decodeInst64 decodes the first instruction in buf.
-func decodeInst64(buf []byte) (disasm.Instruction, error) {
+func decodeInst64(addr bin.Address, buf []byte) (disasm.Instruction, error) {
 	const mode = 64 // x86 (64-bit)
 	inst, err := x86asm.Decode(buf, mode)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return inst, nil
+	return &Instruction{Inst: inst, addr: addr}, nil
+}
+
+// Instruction is an x86 assembly instruction.
+type Instruction struct {
+	x86asm.Inst
+	// Address of the instruction.
+	addr bin.Address
+}
+
+// Addr returns the address of the instruction.
+func (inst *Instruction) Addr() bin.Address {
+	return inst.addr
 }

--- a/cmd/pi-disasm-new/disasm/x86/x86.go
+++ b/cmd/pi-disasm-new/disasm/x86/x86.go
@@ -1,0 +1,36 @@
+// Package x86 implements a disassembler for the 32- and 64-bit x86 machine
+// architectures.
+package x86
+
+import (
+	"github.com/decomp/exp/bin"
+	"github.com/lapsang-boys/pippi/cmd/pi-disasm-new/disasm"
+	"github.com/pkg/errors"
+	"golang.org/x/arch/x86/x86asm"
+)
+
+func init() {
+	// Register disassemblers for x86_32 and x86_64.
+	disasm.RegisterFormat(bin.ArchX86_32.String(), bin.ArchX86_32, decodeInst32)
+	disasm.RegisterFormat(bin.ArchX86_64.String(), bin.ArchX86_64, decodeInst64)
+}
+
+// decodeInst32 decodes the first instruction in buf.
+func decodeInst32(buf []byte) (disasm.Instruction, error) {
+	const mode = 32 // x86 (32-bit)
+	inst, err := x86asm.Decode(buf, mode)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return inst, nil
+}
+
+// decodeInst64 decodes the first instruction in buf.
+func decodeInst64(buf []byte) (disasm.Instruction, error) {
+	const mode = 64 // x86 (64-bit)
+	inst, err := x86asm.Decode(buf, mode)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return inst, nil
+}

--- a/cmd/pi-disasm-new/extract_inst_addrs.go
+++ b/cmd/pi-disasm-new/extract_inst_addrs.go
@@ -1,0 +1,96 @@
+//+build ignore
+
+// The extract_inst_addrs tool extracts instruction address of binaries using
+// the objdump tool (*.bin -> *.json).
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/decomp/exp/bin"
+	"github.com/mewkiz/pkg/jsonutil"
+	"github.com/pkg/errors"
+)
+
+func usage() {
+	const use = `
+Usage:
+
+extract_inst_addrs [OPTION]... BIN_FILE
+
+Extract instruction addresses of binaries (*.bin -> *.json).`
+	fmt.Fprintln(os.Stderr, use[1:])
+	flag.PrintDefaults()
+}
+
+func main() {
+	// Parse command line arguments.
+	flag.Usage = usage
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	binPath := flag.Arg(0)
+	// Extract instruction addresses.
+	instAddrs, err := extractInstAddrs(binPath)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	if err := jsonutil.Write(os.Stdout, instAddrs); err != nil {
+		log.Fatalf("%+v", err)
+	}
+}
+
+// extractInstAddrs extracts the instruction addresses of the given binary using
+// the objdump tool.
+func extractInstAddrs(binPath string) ([]bin.Address, error) {
+	cmd := exec.Command("objdump", "-d", binPath)
+	buf, err := cmd.Output()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	// $ objdump -d /usr/bin/ls
+	//
+	// /usr/bin/ls:     file format elf64-x86-64
+	//
+	// Disassembly of section .init:
+	//
+	// 0000000000004000 <.init>:
+	//     4000:	f3 0f 1e fa          	endbr64
+	//     4004:	48 83 ec 08          	sub    $0x8,%rsp
+	//     4008:	48 8b 05 59 de 01 00 	mov    0x1de59(%rip),%rax
+	var instAddrs []bin.Address
+	s := bufio.NewScanner(bytes.NewReader(buf))
+	for s.Scan() {
+		line := s.Text()
+		// Instruction lines are prefixed with space, filter other lines.
+		//
+		//     4000:	f3 0f 1e fa          	endbr64
+		if !strings.HasPrefix(line, " ") {
+			// skip line not starting with space.
+			continue
+		}
+		pos := strings.IndexByte(line, ':')
+		if pos == -1 {
+			// skip line not containing colon.
+			continue
+		}
+		line = "0x" + strings.TrimSpace(line[:pos])
+		// Parse address.
+		// TODO: check if we need to prefix with 0x before calling bin.Address.Set.
+		var instAddr bin.Address
+		if err := instAddr.Set(line); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		instAddrs = append(instAddrs, instAddr)
+	}
+	return instAddrs, nil
+}

--- a/cmd/pi-disasm-new/main.go
+++ b/cmd/pi-disasm-new/main.go
@@ -7,10 +7,10 @@ import (
 	"os"
 
 	"github.com/decomp/exp/bin"
-	_ "github.com/decomp/exp/bin/elf"
-	_ "github.com/decomp/exp/bin/pe"
+	_ "github.com/decomp/exp/bin/elf" // register ELF decoder
+	_ "github.com/decomp/exp/bin/pe"  // register PE decoder
 	"github.com/lapsang-boys/pippi/cmd/pi-disasm-new/disasm"
-	_ "github.com/lapsang-boys/pippi/cmd/pi-disasm-new/disasm/x86"
+	_ "github.com/lapsang-boys/pippi/cmd/pi-disasm-new/disasm/x86" // register 32- and 64-bit x86 disassemblers
 	"github.com/mewkiz/pkg/jsonutil"
 	"github.com/mewkiz/pkg/pathutil"
 	"github.com/mewkiz/pkg/term"

--- a/cmd/pi-disasm-new/main.go
+++ b/cmd/pi-disasm-new/main.go
@@ -55,7 +55,7 @@ func main() {
 		log.Fatalf("%+v", err)
 	}
 	for _, inst := range insts {
-		fmt.Println(inst)
+		fmt.Printf("0x%08X    %v\n", uint64(inst.Addr()), inst)
 	}
 }
 
@@ -94,7 +94,7 @@ func disasmBinary(db *Database, binPath string) ([]disasm.Instruction, error) {
 	var insts []disasm.Instruction
 	for _, instAddr := range db.InstAddrs {
 		data := file.Code(instAddr)
-		inst, err := dis.DecodeInst(data)
+		inst, err := dis.DecodeInst(instAddr, data)
 		if err != nil {
 			//fmt.Fprintln(os.Stderr, hex.Dump(data))
 			warn.Printf("unable to decode instruction at address %v", instAddr)

--- a/cmd/pi-disasm-new/main.go
+++ b/cmd/pi-disasm-new/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/decomp/exp/bin"
+	_ "github.com/decomp/exp/bin/elf"
+	_ "github.com/decomp/exp/bin/pe"
+	"github.com/lapsang-boys/pippi/cmd/pi-disasm-new/disasm"
+	_ "github.com/lapsang-boys/pippi/cmd/pi-disasm-new/disasm/x86"
+	"github.com/mewkiz/pkg/jsonutil"
+	"github.com/mewkiz/pkg/pathutil"
+	"github.com/mewkiz/pkg/term"
+	"github.com/pkg/errors"
+)
+
+var (
+	// dbg is a logger with the "pi-disasm-new:" prefix which logs debug messages
+	// to standard error.
+	dbg = log.New(os.Stderr, term.CyanBold("pi-disasm-new:")+" ", 0)
+	// warn is a logger with the "pi-disasm-new:" prefix which logs warning
+	// messages to standard error.
+	warn = log.New(os.Stderr, term.RedBold("pi-disasm-new:")+" ", 0)
+)
+
+func usage() {
+	const use = `
+Usage:
+
+pi-disasm-new [OPTION]... BIN_FILE`
+	fmt.Fprintln(os.Stderr, use[1:])
+	flag.PrintDefaults()
+}
+
+func main() {
+	// Parse command line arguments.
+	flag.Usage = usage
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	binPath := flag.Arg(0)
+	// Parse database.
+	db, err := parseDatabase(binPath)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	// Disassemble binary file.
+	insts, err := disasmBinary(db, binPath)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	for _, inst := range insts {
+		fmt.Println(inst)
+	}
+}
+
+// A Database holds the state of a reverse engineering project.
+type Database struct {
+	// Addresses of instructions in the binary.
+	InstAddrs []bin.Address
+}
+
+// parseDatabase parses the database of the given binary.
+func parseDatabase(binPath string) (*Database, error) {
+	dbPath := pathutil.TrimExt(binPath) + ".json"
+	var instAddrs []bin.Address
+	if err := jsonutil.ParseFile(dbPath, &instAddrs); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	db := &Database{
+		InstAddrs: instAddrs,
+	}
+	return db, nil
+}
+
+// disasmBinary disassembles the given binary.
+func disasmBinary(db *Database, binPath string) ([]disasm.Instruction, error) {
+	// Parse bianry file.
+	file, err := bin.ParseFile(binPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	// Create disassembler based on machine architecture.
+	dis, err := disasm.NewDisassembler(file.Arch)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	// Disassemble instructions.
+	var insts []disasm.Instruction
+	for _, instAddr := range db.InstAddrs {
+		data := file.Code(instAddr)
+		inst, err := dis.DecodeInst(data)
+		if err != nil {
+			//fmt.Fprintln(os.Stderr, hex.Dump(data))
+			warn.Printf("unable to decode instruction at address %v", instAddr)
+			continue
+		}
+		insts = append(insts, inst)
+	}
+	return insts, nil
+}


### PR DESCRIPTION
The design is of the disasm package mirrors that of the
image package in the Go standard library but for decoding
instructions of machine architecture formats instead of
image formats. Noteably, the disasm package uses a
RegisterFormat function to register new disassemblers.

A user of the disasm package includes the machine
architecture disassemblers relevant to them, by e.g.:

	import _ ".../disasm/x86"

To separate concerns regarding data/code distinction, the
disassembler simply parses a "database" containing a list
of instruction addresses.

A stand-alone-script has been included to produce a naive
database of instruction addresses using the objdump tool.
Note that objdump is known to include faults instruction
addresses, and as such, expect to see warning messages
printed to standard error when using the disassembler.

~Depends on #16.~

Example run from the `pippi` repo:

Extract list of instruction addresses (using a wrapper around the objdump tool).
```bash
$ cd ./cmd/pi-disasm-new/
$ cp /usr/bin/ls .
$ go run extract_inst_addrs.go ls > ls.json
```

Contents of `ls.json` (contains a list of addresses, one per instruction):
```bash
$ cat ls.json
[
	"0x4000",
	"0x4004",
	"0x4008",
	"0x400F",
	...
	"0x16DA4",
	"0x16DA8",
	"0x16DAC",
	"0x16DB0"
]
```

Disassemble binary:
```
$ pi-disasm-new ls
0x00004000    REP Op(0)
0x00004004    SUB RSP, 0x8
0x00004008    MOV RAX, [RIP+0x1de59]
0x0000400F    TEST RAX, RAX
...
0x00016DA4    REP Op(0)
0x00016DA8    SUB RSP, 0x8
0x00016DAC    ADD RSP, 0x8
0x00016DB0    RET
```
