### PR TITLE
circleci: revert back to v0.0.6 docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
 
   generate-proto:
     docker:
-      - image: karlekdocker/pippi:0.0.8
+      - image: karlekdocker/pippi:0.0.6
 
     steps:
       - *attach_workspace
@@ -38,7 +38,7 @@ jobs:
 
   build-pippi:
     docker:
-      - image: karlekdocker/pippi:0.0.8
+      - image: karlekdocker/pippi:0.0.6
 
     environment: # environment variables for the build itself
       NG_CLI_ANALYTICS: false # https://stackoverflow.com/a/57586959
@@ -184,7 +184,7 @@ jobs:
 
   build-pi-strings:
     docker:
-      - image: karlekdocker/pippi:0.0.8
+      - image: karlekdocker/pippi:0.0.6
 
     steps:
       - checkout # check out source code to working directory


### PR DESCRIPTION
This includes the old stable release of Wails (v0.17.0).
It also contains the old protobuf compiler tools.