### PR TITLE
wailsapp/webview: silence web view warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/wailsapp/wails v0.17.0
+	github.com/wailsapp/webview v0.2.7
 	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be // indirect
@@ -25,3 +26,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/wailsapp/webview => github.com/mewpull/webview v0.5.1-0.20191009214754-e5c797c746e1

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/mewkiz/pkg v0.0.0-20190317153131-e8616647c365/go.mod h1:NefHmmDOyP6U1
 github.com/mewmew/float v0.0.0-20181121163145-c0f786d7da73/go.mod h1:obQBs6O+vjhgOZLkGdALxItKw4xrI49lSBEnAMO6lWI=
 github.com/mewmew/mips v0.1.0 h1:Q/HkKuzmNBOcOkk89BYlMNx6A83+r1bXVTgURDVhMGI=
 github.com/mewmew/mips v0.1.0/go.mod h1:kb5KbF/SaFx88mvIiDEB0WbADlFZONVYkrpKd4MNhGE=
+github.com/mewpull/webview v0.5.1-0.20191009214754-e5c797c746e1 h1:Tz0NHF31ZqpWWXjPxNteSmqX4MkrrVsqSDdsbK+nPzE=
+github.com/mewpull/webview v0.5.1-0.20191009214754-e5c797c746e1/go.mod h1:XO9HJbKWokDxUYTWQEBCYg95n/To1v7PxvanDNVf8hY=
 github.com/mewrev/pe v0.0.0-20181024063030-8f6d1d7d219c/go.mod h1:j2bWMf/wUNeLV/IHgoCdLiulUruBpCmuP6wGmhQxZOA=
 github.com/mewspring/tools v0.0.0-20181204020634-6c6637dc82b6/go.mod h1:UAdVbSksr+7Bg+z4mga16OaBg3qAcgdaF3x3AeqJHEs=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=


### PR DESCRIPTION
`go install ./...` is not silence once more!

This is done by updating the go.mod with a
replacement directive until
wailsapp/webview#2 is merged and a new
release of wailsapp/wails is issued which
depends on the latest webview. At that point,
we should just get rid of the replacement
directive in the go.mod.